### PR TITLE
Use async runOnce.

### DIFF
--- a/primary/ledger-save.js
+++ b/primary/ledger-save.js
@@ -9,6 +9,7 @@ const brIdentity = require('bedrock-identity');
 const config = bedrock.config;
 const brLedgerAgent = require('bedrock-ledger-agent');
 const logger = require('./logger');
+const {callbackify, promisify} = require('util');
 
 // module API
 const api = {};
@@ -42,8 +43,8 @@ function setupLedger(callback) {
       }
       // if no ledger agents are found, create the ledger node and agent
       if(!found) {
-        return bedrock.runOnce(
-          'ledger-test.createLedger', _createLedger, err => {
+        return callbackify(bedrock.runOnce)(
+          'ledger-test.createLedger', promisify(_createLedger), err => {
             if(err) {
               return callback(err);
             }


### PR DESCRIPTION
- Update to use async runOnce vs callback runOnce. Using quick fix for
  the older callback style.

- Using async/await style would be better but this quick fix works.
- Wait to merge until appropriate bedrock PR is released.